### PR TITLE
Replacing 'SetWindowLongPtrA' with 'SetParent' on windows

### DIFF
--- a/lib/windows.cc
+++ b/lib/windows.cc
@@ -204,7 +204,7 @@ Napi::Boolean setWindowOwner(const Napi::CallbackInfo &info) {
     auto newOwner{
         static_cast<LONG_PTR>(info[1].As<Napi::Number>().Int64Value())};
 
-    SetWindowLongPtrA(handle, GWLP_HWNDPARENT, newOwner);
+    SetParent(handle, (HWND)newOwner);
 
     return Napi::Boolean::New(env, true);
 }


### PR DESCRIPTION
According to windows doc: 
`
Do not call SetWindowLongPtr with the GWLP_HWNDPARENT index to change the parent of a child window. Instead, use the SetParent function.
`