### PR TITLE
docs(readme): fix module name in usage sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install node-window-manager
 The following example shows how to get the currently focused window's title and hide it.
 
 ```javascript
-const { windowManager } = require("window-manager");
+const { windowManager } = require("node-window-manager");
 
 const window = windowManager.getActiveWindow();
 


### PR DESCRIPTION
Congrats for the great work, guys! 🌟 

Just a small fix in this PR.

I was taking a look at it and then I realized that [this commit](https://github.com/sentialx/node-window-manager/commit/0291f894ef62ab941c7a9a79c62c00ddb7e2acc8) changed the package name from `window-manager` to `node-window-manager`, but the usage sample on README was left untouched.

As it might confuse new users, not too familiar with NodeJS environment, I think it's important to have it updated accordingly.