### PR TITLE
refactor: remove `window.getInfo`

### DIFF
--- a/example.js
+++ b/example.js
@@ -3,12 +3,12 @@ const { windowManager } = require("./dist/index");
 console.log(windowManager.requestAccessibility()); // required on macOS
 
 const window = windowManager.getActiveWindow();
-// console.log(window.getTitle());
+console.log(window.getTitle());
 
 const bounds = window.getBounds();
 console.log(bounds);
 
-// window.setBounds({ x: 0, y: 0 });
+window.setBounds({ x: 0, y: 0 });
 window.maximize();
 
 setTimeout(() => {
@@ -20,6 +20,10 @@ windowManager.getWindows().forEach(window => {
    if (window.isVisible()) {
       console.log(window.path);
    }
+});
+
+windowManager.on('window-activated', (window) => {
+   console.log(window.path);
 });
 
 console.log("Monitors list");

--- a/example.js
+++ b/example.js
@@ -1,9 +1,9 @@
 const { windowManager } = require("./dist/index");
 
-windowManager.requestAccessibility(); // required on macOS
+console.log(windowManager.requestAccessibility()); // required on macOS
 
 const window = windowManager.getActiveWindow();
-console.log(window.getTitle());
+// console.log(window.getTitle());
 
 const bounds = window.getBounds();
 console.log(bounds);
@@ -18,7 +18,7 @@ setTimeout(() => {
 console.log("Windows list");
 windowManager.getWindows().forEach(window => {
    if (window.isVisible()) {
-      console.log(window.getTitle());
+      console.log(window.path);
    }
 });
 

--- a/example.js
+++ b/example.js
@@ -17,10 +17,12 @@ setTimeout(() => {
 
 console.log("Windows list");
 windowManager.getWindows().forEach(window => {
-   console.log(window.getInfo());
+   if (window.isVisible()) {
+      console.log(window.getTitle());
+   }
 });
 
 console.log("Monitors list");
 windowManager.getMonitors().forEach(monitor => {
-   console.log(monitor.getInfo());
+   console.log(monitor.getWorkArea());
 });

--- a/lib/macos.mm
+++ b/lib/macos.mm
@@ -283,8 +283,6 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
                 Napi::Function::New(env, getWindows));
     exports.Set(Napi::String::New(env, "getActiveWindow"),
                 Napi::Function::New(env, getActiveWindow));
-    exports.Set(Napi::String::New(env, "getWindowInfo"),
-                Napi::Function::New(env, getWindowInfo));
     exports.Set(Napi::String::New(env, "setWindowBounds"),
                 Napi::Function::New(env, setWindowBounds));
     exports.Set(Napi::String::New(env, "getWindowBounds"),

--- a/lib/windows.cc
+++ b/lib/windows.cc
@@ -258,7 +258,7 @@ Napi::Boolean isWindow (const Napi::CallbackInfo& info) {
     return Napi::Boolean::New (env, IsWindow (handle));
 }
 
-Napi::Boolean isVisible (const Napi::CallbackInfo& info) {
+Napi::Boolean isWindowVisible (const Napi::CallbackInfo& info) {
     Napi::Env env{ info.Env () };
 
     auto handle{ getValueFromCallbackData<HWND> (info, 0) };
@@ -308,7 +308,7 @@ Napi::Object Init (Napi::Env env, Napi::Object exports) {
     exports.Set (Napi::String::New (env, "bringWindowToTop"), Napi::Function::New (env, bringWindowToTop));
     exports.Set (Napi::String::New (env, "redrawWindow"), Napi::Function::New (env, redrawWindow));
     exports.Set (Napi::String::New (env, "isWindow"), Napi::Function::New (env, isWindow));
-    exports.Set (Napi::String::New (env, "isVisible"), Napi::Function::New (env, isVisible));
+    exports.Set (Napi::String::New (env, "isWindowVisible"), Napi::Function::New (env, isWindowVisible));
     exports.Set (Napi::String::New (env, "setWindowOpacity"), Napi::Function::New (env, setWindowOpacity));
     exports.Set (Napi::String::New (env, "toggleWindowTransparency"),
                  Napi::Function::New (env, toggleWindowTransparency));

--- a/src/classes/monitor.ts
+++ b/src/classes/monitor.ts
@@ -2,37 +2,32 @@ import { addon } from "..";
 import { IMonitorInfo, IRectangle } from "../interfaces";
 import { release } from "os";
 
+const getMonitorInfo = (id: number): IMonitorInfo => {
+  if (!addon || !addon.getMonitorInfo) return;
+  return addon.getMonitorInfo(id);
+}
+
 export class Monitor {
   public id: number;
 
   constructor(id: number) {
-    if (process.platform !== 'win32' || !addon) return;
-
     this.id = id;
   }
 
-  getInfo(): IMonitorInfo {
-    if (process.platform !== 'win32' || !addon) return;
-    return addon.getMonitorInfo(this.id);
-  }
-
   getBounds(): IRectangle {
-    if (process.platform !== 'win32' || !addon) return;
-    return this.getInfo().bounds;
+    return getMonitorInfo(this.id).bounds;
   }
 
   getWorkArea(): IRectangle {
-    if (process.platform !== 'win32' || !addon) return;
-    return this.getInfo().workArea;
+    return getMonitorInfo(this.id).workArea;
   }
 
   isPrimary(): boolean {
-    if (process.platform !== 'win32' || !addon) return;
-    return this.getInfo().isPrimary;
+    return getMonitorInfo(this.id).isPrimary;
   }
 
   getScaleFactor(): number {
-    if (process.platform !== 'win32' || !addon) return;
+    if (!addon || !addon.getMonitorScaleFactor) return;
 
     const numbers = release()
       .split(".")

--- a/src/classes/window.ts
+++ b/src/classes/window.ts
@@ -21,7 +21,7 @@ export class Window {
   getBounds(): IRectangle {
     if (!addon) return;
 
-    const { bounds } = addon.getWindowBounds(this.id);
+    const bounds = addon.getWindowBounds(this.id);
 
     if (process.platform === "win32") {
       const sf = this.getMonitor().getScaleFactor();

--- a/src/classes/window.ts
+++ b/src/classes/window.ts
@@ -1,8 +1,7 @@
-import { platform } from "os";
 import { addon } from "..";
 import extractFileIcon from 'extract-file-icon';
 import { Monitor } from "./monitor";
-import { IRectangle, IWindowInfo } from "../interfaces";
+import { IRectangle } from "../interfaces";
 
 export class Window {
   public id: number;
@@ -14,7 +13,7 @@ export class Window {
     if (!addon) return;
 
     this.id = id;
-    const { processId, path } = this.getInfo();
+    const { processId, path } = addon.initWindow(id);
     this.processId = processId;
     this.path = path;
   }
@@ -22,9 +21,9 @@ export class Window {
   getBounds(): IRectangle {
     if (!addon) return;
 
-    const { bounds } = this.getInfo();
+    const { bounds } = addon.getWindowBounds(this.id);
 
-    if (platform() === "win32") {
+    if (process.platform === "win32") {
       const sf = this.getMonitor().getScaleFactor();
 
       bounds.x = Math.floor(bounds.x / sf);
@@ -41,7 +40,7 @@ export class Window {
 
     const newBounds = { ...this.getBounds(), ...bounds };
 
-    if (platform() === "win32") {
+    if (process.platform === "win32") {
       const sf = this.getMonitor().getScaleFactor();
 
       newBounds.x = Math.floor(newBounds.x * sf);
@@ -50,14 +49,14 @@ export class Window {
       newBounds.height = Math.floor(newBounds.height * sf);
 
       addon.setWindowBounds(this.id, newBounds);
-    } else if (platform() === "darwin") {
+    } else if (process.platform === "darwin") {
       addon.setWindowBounds(this.id, newBounds);
     }
   }
 
   getTitle(): string {
     if (!addon) return;
-    return this.getInfo().title;
+    return addon.getWindowTitle(this.id);
   }
 
   getMonitor(): Monitor {
@@ -78,9 +77,9 @@ export class Window {
   minimize() {
     if (!addon) return;
 
-    if (platform() === "win32") {
+    if (process.platform === "win32") {
       addon.showWindow(this.id, "minimize");
-    } else if (platform() === "darwin") {
+    } else if (process.platform === "darwin") {
       addon.setWindowMinimized(this.id, true);
     }
   }
@@ -88,25 +87,26 @@ export class Window {
   restore() {
     if (!addon) return;
 
-    if (platform() === "win32") {
+    if (process.platform === "win32") {
       addon.showWindow(this.id, "restore");
-    } else if (platform() === "darwin") {
+    } else if (process.platform === "darwin") {
       addon.setWindowMinimized(this.id, false);
     }
   }
 
   maximize() {
-    if(platform() === "win32") {
-      if (!addon || !addon.showWindow) return;
+    if (!addon) return;
+
+    if (process.platform === "win32") {
       addon.showWindow(this.id, "maximize");
-    } else if(platform() === "darwin") {
-      if (!addon) return;
+    } else if (process.platform === "darwin") {
       addon.setWindowMaximized(this.id);
     } 
   }
 
   bringToTop() {
     if (!addon) return;
+    
     if (process.platform === 'darwin') {
       addon.bringWindowToTop(this.id, this.processId);
     } else {
@@ -121,13 +121,17 @@ export class Window {
 
   isWindow(): boolean {
     if (!addon) return;
-    if (platform() === "win32") return this.path && this.path !== '' && addon.isWindow(this.id);
-    else if (platform() === "darwin") return this.path && this.path !== '' && !!this.getInfo();
+
+    if (process.platform === "win32") {
+      return this.path && this.path !== '' && addon.isWindow(this.id);
+    } else if (process.platform === "darwin") {
+      return this.path && this.path !== '' && !!addon.initWindow(this.id);
+    }
   }
 
   isVisible(): boolean {
-    if (!addon) return;
-    if (platform() === "win32") return addon.isVisible(this.id);
+    if (!addon || !addon.isWindowVisible) return true;
+    return addon.isWindowVisible(this.id);
   }
 
   toggleTransparency(toggle: boolean) {
@@ -141,8 +145,8 @@ export class Window {
   }
 
   getOpacity() {
-    if (platform() !== "win32") return;
-    return this.getInfo().opacity;
+    if (!addon || !addon.getWindowOpacity) return 1;
+    return addon.getWindowOpacity(this.id);
   }
 
   getIcon(size: 16 | 32 | 64 | 256 = 64) {
@@ -150,7 +154,7 @@ export class Window {
   }
 
   setOwner(window: Window | null | number) {
-    if (!addon || platform() !== "win32") return;
+    if (!addon || !addon.setWindowOwner) return;
 
     let handle = window;
 
@@ -164,13 +168,7 @@ export class Window {
   }
 
   getOwner() {
-    if (!addon || platform() !== "win32") return;
-    return new Window(this.getInfo().owner);
-  }
-
-  getInfo(): IWindowInfo {
-    if (!addon) return;
-    const info = addon.getWindowInfo(this.id);
-    return info;
+    if (!addon || !addon.getWindowOwner) return;
+    return new Window(addon.getWindowOwner(this.id));
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ class WindowManager extends EventEmitter {
   }
 
   requestAccessibility = () => {
-    if (platform() !== 'darwin') return true;
+    if (!addon || !addon.requestAccessibility) return true;
     return addon.requestAccessibility();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,8 @@ import { Monitor } from "./classes/monitor";
 let addon: any;
 
 if (platform() === "win32" || platform() === "darwin") {
-  let path_addon: string = (process.env.NODE_ENV != "dev") ? "Release" : "Debug";
-  addon = require(`../build/${path_addon}/addon.node`);
+  const ADDON_PATH = (process.env.NODE_ENV != "dev") ? "Release" : "Debug";
+  addon = require(`../build/${ADDON_PATH}/addon.node`);
 }
 
 let interval: any = null;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -5,16 +5,6 @@ export interface IRectangle {
   height?: number;
 }
 
-export interface IWindowInfo {
-  id: number;
-  path: string;
-  processId: number;
-  title?: string;
-  bounds?: IRectangle;
-  opacity?: number;
-  owner?: number;
-}
-
 export interface IMonitorInfo {
   id: number;
   bounds?: IRectangle;


### PR DESCRIPTION
Closes #27, #20 

`window.getInfo` was also getting the window's title which requires also some additional permissions on macOS. It was the cause of crashes in issue #27.