### PR TITLE
MAC: Fix App Object OverRelease Crash and Window Info Retrieval

### DIFF
--- a/lib/macos.mm
+++ b/lib/macos.mm
@@ -30,8 +30,9 @@ NSDictionary* getWindowInfo(int handle) {
     NSNumber *windowNumber = info[(id)kCGWindowNumber];
 
     if ([windowNumber intValue] == handle) {
-      CFRelease(windowList);
-      return info;
+        NSDictionary* windowInfo = (NSDictionary*)CFPropertyListCreateDeepCopy(kCFAllocatorDefault, (CFPropertyListRef)info, kCFPropertyListMutableContainers);
+        CFRelease(windowList);
+        return windowInfo;
     }
   }
 
@@ -136,11 +137,9 @@ Napi::Number getActiveWindow(const Napi::CallbackInfo &info) {
     auto app = [NSRunningApplication runningApplicationWithProcessIdentifier: [ownerPid intValue]];
 
     if (![app isActive]) {
-      [app release];
       continue;
     }
 
-    [app release];
     CFRelease(windowList);
     return Napi::Number::New(env, [windowNumber intValue]);
   }
@@ -166,7 +165,6 @@ Napi::Object initWindow(const Napi::CallbackInfo &info) {
 
     cacheWindow(handle, [ownerPid intValue]);
 
-    [app release];
     return obj;
   }
 


### PR DESCRIPTION
- @sentialx this is related to #43 . I got a bit overzealous and cleaned some objects that were automaticlly released later, causing the following error

```
objc[38928]: NSRunningApplication object 0x7fd721504390 overreleased while already deallocating; break on objc_overrelease_during_dealloc_error to debug
```

- Second issue here is because we `CFRelease(windowList)`, the internal dictionary we returned may throw an exception when accessed. Fixed that here too

I was finally able to get this to run in xcode debug mode and tracked these down, sorry about the regression in the last release
