### PR TITLE
MAC OSX: AXUIElement Bad Access Ref

### DIFF
--- a/lib/macos.mm
+++ b/lib/macos.mm
@@ -77,7 +77,7 @@ void cacheWindowByInfo(NSDictionary* info) {
   if (info) {
     NSNumber *ownerPid = info[(id)kCGWindowOwnerPID];
     NSNumber *windowNumber = info[(id)kCGWindowNumber];
-    // Release dictionary info property since we're don't with it
+    // Release dictionary info property since we're done with it
     CFRelease((CFPropertyListRef)info);
     cacheWindow([windowNumber intValue], [ownerPid intValue]);
   }


### PR DESCRIPTION
- Small fix here to manually retain the AUXUIElement ref we cache, so it stays around after releasing the rest of the windows. See: https://developer.apple.com/documentation/corefoundation/1521269-cfretain?language=objc
- Avoid copying property list and just retain it

@sentialx I think I got all the mem leak fixes I found debugging. Thanks for the quick turn around w. the release 👍 