### PR TITLE
Fix Window Offscreen Windows Lookup Crash

### DIFF
--- a/lib/macos.mm
+++ b/lib/macos.mm
@@ -37,7 +37,9 @@ NSDictionary* getWindowInfo(int handle) {
     }
   }
 
-  CFRelease(windowList);
+  if (windowList) {
+    CFRelease(windowList);
+  }
   return NULL;
 }
 
@@ -61,7 +63,9 @@ AXUIElementRef getAXWindow(int pid, int handle) {
     }
   }
 
-  CFRelease(windows);
+  if (windows) {
+    CFRelease(windows);
+  }
   return NULL;
 }
 
@@ -124,7 +128,10 @@ Napi::Array getWindows(const Napi::CallbackInfo &info) {
     arr[i] = vec[i];
   }
 
-  CFRelease(windowList);
+  if (windowList) {
+    CFRelease(windowList);
+  }
+  
   return arr;
 }
 
@@ -148,7 +155,9 @@ Napi::Number getActiveWindow(const Napi::CallbackInfo &info) {
     return Napi::Number::New(env, [windowNumber intValue]);
   }
 
-  CFRelease(windowList);
+  if (windowList) {
+    CFRelease(windowList);
+  }
   return Napi::Number::New(env, 0);
 }
 


### PR DESCRIPTION
Switching to an application that has a single offscreen window (ex: an app in fullscreen mode) causes `CGWindowListCopyWindowInfo` call to return an empty `CFArrayRef`. Attempting to release this array will throw the error below. 

- Fix: Check if `CFArray` pointers are null before releasing

![image](https://user-images.githubusercontent.com/684657/80409423-b3f9bf00-887d-11ea-9aec-161bc9b599f0.png)

@sentialx got another one for ya :)