### PR TITLE
fix: MacOS getTitle() - segmentation fault

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,5 +53,17 @@
     "mutex": "cpp",
     "ratio": "cpp",
     "thread": "cpp"
-  }
+  },
+  "workbench.colorCustomizations": {
+    "statusBar.background": "#557c9b",
+    "statusBar.border": "#557c9b",
+    "statusBar.foreground": "#e7e7e7",
+    "statusBarItem.hoverBackground": "#7295b1",
+    "titleBar.activeBackground": "#557c9b",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.border": "#557c9b",
+    "titleBar.inactiveBackground": "#557c9b99",
+    "titleBar.inactiveForeground": "#e7e7e799"
+  },
+  "peacock.color": "#557c9b"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,17 +53,5 @@
     "mutex": "cpp",
     "ratio": "cpp",
     "thread": "cpp"
-  },
-  "workbench.colorCustomizations": {
-    "statusBar.background": "#557c9b",
-    "statusBar.border": "#557c9b",
-    "statusBar.foreground": "#e7e7e7",
-    "statusBarItem.hoverBackground": "#7295b1",
-    "titleBar.activeBackground": "#557c9b",
-    "titleBar.activeForeground": "#e7e7e7",
-    "titleBar.border": "#557c9b",
-    "titleBar.inactiveBackground": "#557c9b99",
-    "titleBar.inactiveForeground": "#e7e7e799"
-  },
-  "peacock.color": "#557c9b"
+  }
 }

--- a/example.js
+++ b/example.js
@@ -18,6 +18,7 @@ setTimeout(() => {
 console.log("Windows list");
 windowManager.getWindows().forEach((window) => {
   if (window.isVisible()) {
+    console.log(window.getTitle());
     console.log(window.path);
   }
 });

--- a/example.js
+++ b/example.js
@@ -12,21 +12,21 @@ window.setBounds({ x: 0, y: 0 });
 window.maximize();
 
 setTimeout(() => {
-   window.setBounds(bounds);
+  window.setBounds(bounds);
 }, 1000);
 
 console.log("Windows list");
-windowManager.getWindows().forEach(window => {
-   if (window.isVisible()) {
-      console.log(window.path);
-   }
+windowManager.getWindows().forEach((window) => {
+  if (window.isVisible()) {
+    console.log(window.path);
+  }
 });
 
-windowManager.on('window-activated', (window) => {
-   console.log(window.path);
+windowManager.on("window-activated", (window) => {
+  console.log(window.path);
 });
 
 console.log("Monitors list");
-windowManager.getMonitors().forEach(monitor => {
-   console.log(monitor.getWorkArea());
+windowManager.getMonitors().forEach((monitor) => {
+  console.log(monitor.getWorkArea());
 });

--- a/example.js
+++ b/example.js
@@ -18,8 +18,7 @@ setTimeout(() => {
 console.log("Windows list");
 windowManager.getWindows().forEach((window) => {
   if (window.isVisible()) {
-    console.log(window.getTitle());
-    console.log(window.path);
+    console.log(window.getTitle(), window.path);
   }
 });
 

--- a/lib/macos.mm
+++ b/lib/macos.mm
@@ -192,7 +192,7 @@ Napi::String getWindowTitle(const Napi::CallbackInfo &info) {
   auto wInfo = getWindowInfo(handle);
 
   if (wInfo) {
-    NSString *windowName = wInfo[(id)kCGWindowName];
+    NSString *windowName = wInfo[(id)kCGWindowOwnerName];
     return Napi::String::New(env, [windowName UTF8String]);
   }
 

--- a/src/classes/window.ts
+++ b/src/classes/window.ts
@@ -1,5 +1,5 @@
 import { addon } from "..";
-import extractFileIcon from 'extract-file-icon';
+import extractFileIcon from "extract-file-icon";
 import { Monitor } from "./monitor";
 import { IRectangle } from "../interfaces";
 import { EmptyMonitor } from "./empty-monitor";
@@ -102,13 +102,13 @@ export class Window {
       addon.showWindow(this.id, "maximize");
     } else if (process.platform === "darwin") {
       addon.setWindowMaximized(this.id);
-    } 
+    }
   }
 
   bringToTop() {
     if (!addon) return;
-    
-    if (process.platform === 'darwin') {
+
+    if (process.platform === "darwin") {
       addon.bringWindowToTop(this.id, this.processId);
     } else {
       addon.bringWindowToTop(this.id);
@@ -124,9 +124,9 @@ export class Window {
     if (!addon) return;
 
     if (process.platform === "win32") {
-      return this.path && this.path !== '' && addon.isWindow(this.id);
+      return this.path && this.path !== "" && addon.isWindow(this.id);
     } else if (process.platform === "darwin") {
-      return this.path && this.path !== '' && !!addon.initWindow(this.id);
+      return this.path && this.path !== "" && !!addon.initWindow(this.id);
     }
   }
 


### PR DESCRIPTION
Hi, @sentialx 

When **`getTitle()`** is invoked; It runs into `segementaion fault` on MacOS. 

After walking the code I found out the culprit line:
https://github.com/sentialx/node-window-manager/blob/8dd45f2dc2ce2293b9b632c41d01f7b776fb3da1/lib/macos.mm#L195
for some reasons `kCGWindowName` fails, so I use `kCGWindowOwnerName` instead.